### PR TITLE
Minor changes to ensure that the demo runs on AWS 

### DIFF
--- a/cloudformation/templates/compute.yml
+++ b/cloudformation/templates/compute.yml
@@ -15,7 +15,7 @@ Resources:
       FunctionName: SUBLambdaFunctionStart
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaStartRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
       Timeout: 10
 
   SUBLambdaFunctionTranscode:
@@ -29,7 +29,7 @@ Resources:
       FunctionName: SUBLambdaFunctionTranscode
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaTranscodeRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
       Timeout: 10
 
   SUBLambdaFunctionTranscribe:
@@ -43,7 +43,7 @@ Resources:
       FunctionName: SUBLambdaFunctionTranscribe
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaTranscribeRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
       Timeout: 10
 
   SUBLambdaFunctionTranscribeIsOver:
@@ -57,7 +57,7 @@ Resources:
       FunctionName: SUBLambdaFunctionTranscribeIsOver
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaTranscribeIsOverRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
 
   SUBLambdaFunctionTranslate:
     Type: "AWS::Lambda::Function"
@@ -70,7 +70,7 @@ Resources:
       FunctionName: SUBLambdaFunctionTranslate
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaTranslateRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
       Timeout: 60
 
   SUBLambdaFunctionOutput:
@@ -84,7 +84,7 @@ Resources:
       FunctionName: SUBLambdaFunctionOutput
       Handler: "index.handler"
       Role: !ImportValue "SUBLambdaOutputRole"
-      Runtime: "python2.7"
+      Runtime: "python3.7"
       Timeout: 10
 
 Outputs:

--- a/cloudformation/templates/storage-permissions.yml
+++ b/cloudformation/templates/storage-permissions.yml
@@ -36,6 +36,7 @@ Resources:
       FunctionName: !ImportValue SUBLambdaFunctionStart
       Principal: "s3.amazonaws.com"
       SourceArn: !GetAtt "SUBS3Media.Arn"
+      SourceAccount: !Sub ${AWS::AccountId}
 
   SUBBucketPolicyMedia:
     Type: "AWS::S3::BucketPolicy"

--- a/lambda/SUBLambdaFunctionTranslate/index.py
+++ b/lambda/SUBLambdaFunctionTranslate/index.py
@@ -1,5 +1,5 @@
 import boto3
-import urllib2
+import requests
 import json
 import re
 from datetime import timedelta
@@ -13,11 +13,8 @@ def callJobTranscription(event):
     response = transcribe.get_transcription_job(TranscriptionJobName=fileUUID)
     transcriptFileUri = response.get("TranscriptionJob") \
         .get("Transcript").get("TranscriptFileUri")
-    req = urllib2.Request(transcriptFileUri)
-    opener = urllib2.build_opener()
-    f = opener.open(req)
-    data = json.loads(f.read())
-    return data.get("results").get("items")
+    req = requests.get(transcriptFileUri)
+    return req.json()["results"]["items"]
 
 
 def makeVTTFile(items):


### PR DESCRIPTION
*Issue #, if available:* 
The demo does not run out of the box on AWS today due to the deprecated Python2.7 runtime and urllib2 module. Further, the S3 trigger for invoking the Start lambda function does not include the S3 source account and can possibly lead to a [confused deputy attack](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), as the S3 bucket ARN does not include the Account ID.

*Description of changes:*
- Switched Python runtime from python2.7 to python3.7
- Added SourceAccount to SUBLambdaFunctionStart permissions to prevent possible confused deputy attack
- Replaced urllib2 by requests module as urllib2 is not available in Python 3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
